### PR TITLE
Redirect dd stderr to null

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -13,7 +13,7 @@ use std::fs;
 use std::fs::{File, OpenOptions};
 use std::io;
 use std::io::{Read, Write};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::path::{Path, PathBuf};
 use std::os::unix::fs::FileExt;
 
@@ -229,6 +229,7 @@ unit_tests!{
         let status = Command::new("dd")
             .arg("if=/dev/zero").arg(of)
             .arg("bs=1M").arg("count=10")
+            .stderr(Stdio::null())
             .status().expect("failed to execute `dd'");
         assert!(status.success());
         


### PR DESCRIPTION
Eliminates unneeded output:

> 10+0 records in
> 10+0 records out
> 10485760 bytes (10 MB, 10 MiB) copied, 0.0884144 s, 119 MB/s