### PR TITLE
Resolve warnings on Linux with latest Rust(1.68.0) and threadpool configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "daemonize"
-version = "0.2.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0239832c1b4ca406d5ec73728cf4c7336d25cf85dd32db9e047e9e706ee0e935"
+checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
 dependencies = [
  "libc",
 ]
@@ -295,9 +295,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.78"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7087f49d294270db4e1928fc110c976cd4b9e5a16348e0a1df09afa99e6c98"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "log"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 backtrace = "0.3"
 chan-signal = "0.2"
 clap = "2.29.0"
-daemonize = "0.2"
+daemonize = "0.5"
 env_logger = "0.4"
 fd = { git = "https://github.com/stemjail/fd-rs.git", rev = "3bc3e3587f8904cce8bf29163a2021c2f5906557" }
 fuse = "0.3.0"

--- a/src/catfs/flags.rs
+++ b/src/catfs/flags.rs
@@ -74,6 +74,8 @@ pub struct FlagStorage {
     pub free_space: DiskSpace,
     pub uid: libc::uid_t,
     pub gid: libc::gid_t,
+    pub catfs_threadpool_size: usize,
+    pub pcatfs_threadpool_size: usize
 }
 
 #[cfg(test)]

--- a/src/catfs/inode.rs
+++ b/src/catfs/inode.rs
@@ -255,14 +255,13 @@ impl Inode {
     }
 
     pub fn truncate(&mut self, size: u64) -> error::Result<()> {
-        let mut f = File::openat(self.src_dir, &self.path, rlibc::O_WRONLY, 0)?;
+        let f = File::openat(self.src_dir, &self.path, rlibc::O_WRONLY, 0)?;
         f.set_size(size)?;
-        f.close()?;
+        std::mem::drop(&f);
 
         match File::openat(self.cache_dir, &self.path, rlibc::O_WRONLY, 0) {
-            Ok(mut f) => {
+            Ok(f) => {
                 f.set_size(size)?;
-                f.close()?;
             }
             Err(e) => {
                 error::try_enoent(e)?;

--- a/src/catfs/mod.rs
+++ b/src/catfs/mod.rs
@@ -110,7 +110,7 @@ pub fn make_self<T>(s: &mut T) -> &'static T {
 }
 
 impl CatFS {
-    pub fn new(from: &dyn AsRef<Path>, to: &dyn AsRef<Path>) -> error::Result<CatFS> {
+    pub fn new(from: &dyn AsRef<Path>, to: &dyn AsRef<Path>, n_threads : usize) -> error::Result<CatFS> {
         let src_dir = rlibc::open(from, rlibc::O_RDONLY, 0)?;
         let cache_dir = rlibc::open(to, rlibc::O_RDONLY, 0)?;
 
@@ -123,7 +123,7 @@ impl CatFS {
             store: Mutex::new(Default::default()),
             dh_store: Mutex::new(Default::default()),
             fh_store: Mutex::new(Default::default()),
-            tp: Mutex::new(ThreadPool::new(5)),
+            tp: Mutex::new(ThreadPool::new(n_threads)),
         };
 
         catfs.make_root()?;

--- a/src/catfs/rlibc.rs
+++ b/src/catfs/rlibc.rs
@@ -14,10 +14,12 @@ use std::ptr;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::io::RawFd;
 use std::os::unix::fs::FileExt;
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard, LockResult};
 
 use self::fuse::FileType;
 use self::time::Timespec;
 use self::xattr::FileExt as XattrFileExt;
+
 
 #[cfg(not(target_os = "macos"))]
 use self::libc::{fstat64, fstatvfs64, ftruncate64, open64, openat64, pread64, pwrite64, stat64, statvfs64};
@@ -47,6 +49,7 @@ pub fn to_cstring(path: &dyn AsRef<Path>) -> CString {
     let bytes = path.as_ref().as_os_str().to_os_string().into_vec();
     return CString::new(bytes).unwrap();
 }
+
 
 macro_rules! libc_wrap {
     ($( pub fn $name:ident($($arg:ident : $argtype:ty),*) $body:block )*) => (
@@ -400,7 +403,7 @@ pub fn fchmodat(dir: RawFd, path: &dyn AsRef<Path>, mode: libc::mode_t, flags: u
 }
 
 pub struct File {
-    fd: libc::c_int,
+    fd: Arc<RwLock<libc::c_int>>,
 }
 
 fn as_void_ptr<T>(s: &[T]) -> *const libc::c_void {
@@ -431,7 +434,15 @@ impl File {
             mode,
             fd
         );
-        return Ok(File { fd: fd });
+        return Ok(File { fd: Arc::new( RwLock::new( fd ) ) });
+    }
+
+    pub fn write_lock(&self) -> LockResult<RwLockWriteGuard<'_, i32>> {
+        return Ok(self.fd.write()?);
+    }
+
+    pub fn read_lock(&self) -> LockResult<RwLockReadGuard<'_, i32>> {
+        return Ok(self.fd.read()?);
     }
 
     #[allow(dead_code)]
@@ -444,42 +455,65 @@ impl File {
             mode,
             fd
         );
-        return Ok(File { fd: fd });
+        return Ok(File { fd: Arc::new(RwLock::new(fd)) });
     }
 
-    pub fn with_fd(fd: libc::c_int) -> File {
-        return File { fd: fd };
+    pub fn clone(&self) -> File {
+        return File { fd: self.fd.clone() };
     }
 
     pub fn valid(&self) -> bool {
-        return self.fd != -1;
+        match self.fd.read() {
+            Ok(fd) => *fd != -1,
+            Err(_) => false
+        }
     }
 
     pub fn filesize(&self) -> io::Result<u64> {
-        let st = fstat(self.fd)?;
-        return Ok(st.st_size as u64);
+        match self.fd.read() {
+            Ok(fd) => {
+                let st = fstat(*fd)?;
+                return Ok(st.st_size as u64);
+            },
+            Err(_) => return Err(io::Error::new(io::ErrorKind::Other, "couldn't get read lock!")),
+        }
     }
 
     pub fn stat(&self) -> io::Result<stat64> {
-        fstat(self.fd)
+        match self.fd.read() {
+            Ok(fd) => {
+                fstat(*fd)
+            },
+            Err(_) => return Err(io::Error::new(io::ErrorKind::Other, "couldn't get read lock!")),
+        }
     }
 
     pub fn truncate(&self, size: u64) -> io::Result<()> {
-        let res = unsafe { ftruncate64(self.fd, size as i64) };
-        if res < 0 {
-            return Err(io::Error::last_os_error());
-        } else {
-            return Ok(());
+        match self.fd.write() {
+            Ok(fd) => {
+                let res = unsafe { ftruncate64(*fd, size as i64) };
+                if res < 0 {
+                    return Err(io::Error::last_os_error());
+                } else {
+                    return Ok(());
+                }
+            },
+            Err(_) => return Err(io::Error::new(io::ErrorKind::Other, "couldn't get write lock!")),
         }
     }
 
     #[cfg(not(target_os = "macos"))]
     pub fn allocate(&self, offset: u64, len: u64) -> io::Result<()> {
-        let res = unsafe { libc::posix_fallocate64(self.fd, offset as i64, len as i64) };
-        if res == 0 {
-            return Ok(());
-        } else {
-            return Err(io::Error::from_raw_os_error(res));
+        match self.fd.write() {
+            Ok(fd) => {
+                let res = unsafe { libc::posix_fallocate64(*fd, offset as i64, len as i64) };
+                if res == 0 {
+                    return Ok(());
+                } else {
+                    return Err(io::Error::from_raw_os_error(res));
+                }
+            },
+            Err(_) => return Err(io::Error::new(io::ErrorKind::Other, "couldn't get write lock!")),
         }
     }
 
@@ -504,17 +538,36 @@ impl File {
     }
 
     pub fn chmod(&self, mode: libc::mode_t) -> io::Result<()> {
-        let res = unsafe { libc::fchmod(self.fd, mode) };
-        if res == 0 {
-            return Ok(());
-        } else {
-            return Err(io::Error::from_raw_os_error(res));
+        match self.fd.write() {
+            Ok(fd) => {
+                let res = unsafe { libc::fchmod(*fd, mode) };
+                if res == 0 {
+                    return Ok(());
+                } else {
+                    return Err(io::Error::from_raw_os_error(res));
+                }
+            },
+            Err(_) => return Err(io::Error::new(io::ErrorKind::Other, "couldn't get write lock!")),
         }
     }
 
     pub fn read_at(&self, buf: &mut [u8], offset: i64) -> io::Result<usize> {
-        let nbytes =
-            unsafe { pread64(self.fd, as_mut_void_ptr(buf), buf.len(), offset) };
+        match self.fd.read() {
+            Ok(fd) => {
+                let nbytes =
+                    unsafe { pread64(*fd, as_mut_void_ptr(buf), buf.len(), offset) };
+                if nbytes < 0 {
+                    return Err(io::Error::last_os_error());
+                } else {
+                    return Ok(nbytes as usize);
+                }
+            },
+            Err(_) => return Err(io::Error::new(io::ErrorKind::Other, "couldn't get read lock!")),
+        }
+    }
+
+    pub fn write_at_nolock(&self, buf: &[u8], offset: i64, fd : i32 ) -> io::Result<usize> {
+        let nbytes = unsafe { pwrite64(fd, as_void_ptr(buf), buf.len(), offset) };
         if nbytes < 0 {
             return Err(io::Error::last_os_error());
         } else {
@@ -523,46 +576,46 @@ impl File {
     }
 
     pub fn write_at(&self, buf: &[u8], offset: i64) -> io::Result<usize> {
-        let nbytes = unsafe { pwrite64(self.fd, as_void_ptr(buf), buf.len(), offset) };
-        if nbytes < 0 {
-            return Err(io::Error::last_os_error());
-        } else {
-            return Ok(nbytes as usize);
+        match self.fd.write() {
+            Ok(fd) => {
+                let nbytes = unsafe { pwrite64(*fd, as_void_ptr(buf), buf.len(), offset) };
+                if nbytes < 0 {
+                    return Err(io::Error::last_os_error());
+                } else {
+                    return Ok(nbytes as usize);
+                }
+            },
+            Err(_) => return Err(io::Error::new(io::ErrorKind::Other, "couldn't get write lock!")),
         }
     }
 
     pub fn flush(&self) -> io::Result<()> {
-        debug!("flush {}", self.fd);
-        // trigger a flush for the underly fd, this could be called
-        // multiple times, for ex:
-        //
-        // int fd2 = dup(fd); close(fd2); close(fd)
-        //
-        // so the fd needs to stay valid. Note that this means when an
-        // application sends close(), kernel will send us
-        // flush()/release(), and we will send close()/close(), which
-        // will be translated to flush()/flush()/release() to the
-        // underlining filesystem
-        let fd = unsafe { libc::dup(self.fd) };
-        if fd < 0 {
-            return Err(io::Error::last_os_error());
-        } else {
-            let res = unsafe { libc::close(fd) };
-            if res < 0 {
-                return Err(io::Error::last_os_error());
-            } else {
-                return Ok(());
-            }
-        }
-    }
-
-    pub fn close(&mut self) -> io::Result<()> {
-        let res = unsafe { libc::close(self.fd) };
-        self.fd = -1;
-        if res < 0 {
-            return Err(io::Error::last_os_error());
-        } else {
-            return Ok(());
+        match self.fd.write() {
+            Ok(wfd) => {
+                debug!("flush {}", *wfd);
+                // trigger a flush for the underly fd, this could be called
+                // multiple times, for ex:
+                //
+                // int fd2 = dup(fd); close(fd2); close(fd)
+                //
+                // so the fd needs to stay valid. Note that this means when an
+                // application sends close(), kernel will send us
+                // flush()/release(), and we will send close()/close(), which
+                // will be translated to flush()/flush()/release() to the
+                // underlining filesystem
+                let fd = unsafe { libc::dup(*wfd) };
+                if fd < 0 {
+                    return Err(io::Error::last_os_error());
+                } else {
+                    let res = unsafe { libc::close(fd) };
+                    if res < 0 {
+                        return Err(io::Error::last_os_error());
+                    } else {
+                        return Ok(());
+                    }
+                }
+            },
+            Err(_) => return Err(io::Error::new(io::ErrorKind::Other, "couldn't get write lock!")),
         }
     }
 
@@ -570,33 +623,35 @@ impl File {
         if !self.valid() {
             error!("as_raw_fd called on invalid fd");
         }
-
-        return self.fd;
-    }
-
-    pub fn into_raw(&mut self) -> RawFd {
-        let fd = self.fd;
-        self.fd = -1;
-        fd
+        match self.fd.read() {
+            Ok(fd) => {
+                return *fd;
+            },
+            Err(_) => return -1,
+        }
     }
 }
 
 impl Default for File {
     fn default() -> File {
-        File { fd: -1 }
+        File { fd: Arc::new( RwLock::new(-1)) }
     }
 }
 
 impl Drop for File {
     fn drop(&mut self) {
-        if self.fd != -1 {
-            error!(
-                "{} dropped but not closed: {}",
-                self.fd,
-                RError::from(io::Error::from_raw_os_error(libc::EIO))
-            );
-            if let Err(e) = self.close() {
-                error!("!close({}) = {}", self.fd, RError::from(e));
+        if Arc::strong_count(&self.fd) == 1 {
+            match self.fd.write() {
+                Ok(fd) => { 
+                    if *fd >= 0 {
+                        let res = unsafe { libc::close(*fd) };
+                        debug!( "<-- closed {} result: {}", *fd, res);
+                        if res < 0 {
+                            error!("!close({}) = {}", *fd, res);
+                        }
+                    }
+                },
+                Err(e) => error!("!close() = {}", e.to_string()),
             }
         }
     }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -86,6 +86,11 @@ pub fn parse_options<'a, 'b>(mut app: clap::App<'a, 'a>, flags: &'b mut [Flag<'a
                 *v = String::from(s);
                 continue;
             }
+            if let Some(v) = f.value.downcast_mut::<usize>() {
+                let s = matches.value_of(name).unwrap();
+                *v = s.parse().unwrap();
+                continue;
+            }
             if let Some(v) = f.value.downcast_mut::<OsString>() {
                 let s = matches.value_of_os(name).unwrap();
                 *v = s.to_os_string();

--- a/src/pcatfs/mod.rs
+++ b/src/pcatfs/mod.rs
@@ -28,9 +28,9 @@ pub fn make_self<T>(s: &mut T) -> &'static mut T {
 }
 
 impl PCatFS {
-    pub fn new(fs: CatFS) -> PCatFS {
+    pub fn new(fs: CatFS, n_threads : usize) -> PCatFS {
         PCatFS {
-            tp: ThreadPool::new(100),
+            tp: ThreadPool::new(n_threads),
             fs: fs,
         }
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -67,8 +67,8 @@ impl<'a> CatFSTests<'a> {
     }
 
     fn mount(&self) -> error::Result<(fuse::BackgroundSession<'a>, Evicter)> {
-        let fs = CatFS::new(&self.src, &self.cache)?;
-        let fs = PCatFS::new(fs);
+        let fs = CatFS::new(&self.src, &self.cache, 5)?;
+        let fs = PCatFS::new(fs, 100);
 
         let cache_dir = fs.get_cache_dir()?;
         // essentially no-op, but ensures that it starts and terminates

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -374,10 +374,9 @@ unit_tests!{
         let foo = f.src.join("file1");
         xattr::set(&foo, "user.catfs.random", b"hello").unwrap();
         rlibc::utimes(&foo, 0, 100000000).unwrap();
-        let mut fh = rlibc::File::open(&foo, rlibc::O_RDONLY, 0).unwrap();
+        let fh = rlibc::File::open(&foo, rlibc::O_RDONLY, 0).unwrap();
         let s = file::Handle::src_str_to_checksum(&fh).unwrap();
         assert_eq!(s, OsStr::new("100000000\n6\n"));
-        fh.close().unwrap();
     }
 
     fn check_dirty(f: &CatFSTests) {


### PR DESCRIPTION
Just some small changes to support the newest Rust as well as resolve #63 

As a side note, instead of a ThreadPool we may want to consider utilizing async instead for concurrently handing blocking io calls.

https://rust-lang.github.io/async-book/02_execution/05_io.html